### PR TITLE
Add support for Laravel 8.x & 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/sipgate/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/sipgate/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/sipgate.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/sipgate)
 
-This package makes it easy to send notifications using [sipgate](https://sipgate.de) with Laravel 5.5+, 6.X and 7.
+This package makes it easy to send notifications using [sipgate](https://sipgate.de) with Laravel 5.5+, 6.x, 7.x, 8.x, 9.x.
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     ],
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "^6.3",
-        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0",
-        "illuminate/support": "~5.5 || ~6.0 || ~7.0",
+        "guzzlehttp/guzzle": "^7.2",
+        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ~8.0 || ~9.0",
+        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ~8.0 || ~9.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Bumped up the dependencies, for it to work with Laravel 8.x and 9.x.

I did test this on 9.x and it works perfectly fine, should also be working on 8.x :)

Additionally this bumps the Guzzle version.

Thank you very much!

Fixes #5 